### PR TITLE
Allow cancancan 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Gemfile.lock
 *.sqlite3
 *.log
 .tm_properties
+.byebug_history

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
 language: ruby
 rvm:
-  - ree
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby-18mode # JRuby in 1.8 mode
+  - 2.0
+  - 2.1
+  - 2.2
+  - 2.3
+  - 2.4
   - jruby-19mode # JRuby in 1.9 mode
-  - rbx-18mode
   - rbx-19mode
 services:
   - mongodb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
-  - 2.4
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-19mode
+  - 2.3.3
+  - 2.4.0
+  - jruby-9.1.5
+  - rubinius-3
 services:
   - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ rvm:
   - 2.3.3
   - 2.4.0
   - jruby-9.1.7.0
-  - rbx-head
+  - rbx-3.71
 services:
   - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ rvm:
   - 2.2
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.5
-  - rubinius-3
+  - jruby-9.1.7.0
+  - rbx-head
 services:
   - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ rvm:
   - 2.3.3
   - 2.4.0
   - jruby-9.1.7.0
-  - rbx-3.71
 services:
   - mongodb
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ Canard
 ======
 [![Build Status](https://travis-ci.org/james2m/canard.svg?branch=master)](https://travis-ci.org/james2m/canard)
 
-Canard brings CanCan and RoleModel together to make role based authorization in Rails easy. Your ability
+Canard brings CanCan and RoleModel together to make role-based authorization in Rails easy. Your ability
 definitions gain their own folder and a little structure. The easiest way to get started is with the
 Canard generator. Canard progressively enhances the abilities of the model by applying role abilities on
-top of the models base abilities.
+top of the model's base abilities.
 A User model with :admin and :manager roles would be defined:
 
     class User < ActiveRecord::Base
@@ -14,32 +14,31 @@ A User model with :admin and :manager roles would be defined:
 
     end
 
-If a User has both the :manager and :admin roles Canard will apply the abilities in the following order.
-First it will look for a users abilities, then it will look for the roles in the order they are defined e.g.
+If a User has both the :manager and :admin roles, Canard looks first for user abilities. Then it will look for other roles in the order that they are defined:
 
     app/abilities/users.rb
     app/abilities/manager.rb
     app/abilities/admin.rb
 
-Therefore each the later abilities only need to build on their predecessors.
+Therefore each of the later abilities can build on its predecessor.
 
 Usage
 =====
-To generate some abilities for the User.
+To generate some abilities for the User:
 
     $ rails g canard:ability user can:[read,create]:[account,statement] cannot:destroy:account
     create  app/abilities/users.rb
     invoke  rspec
     create    spec/abilities/user_spec.rb
 
-Generates an ability folder in Rails root and an associated spec;
+This action generates an ability folder in Rails root and an associated spec:
 
     app.abilities/
       users.rb
     spec/abilities/
       users_spec.rb
 
-The resulting app/abilities/users.rb will look something like this;
+The resulting app/abilities/users.rb will look something like this:
 
     Canard::Abilities.for(:user) do
 
@@ -49,7 +48,7 @@ The resulting app/abilities/users.rb will look something like this;
 
     end
 
-And it's associated test spec/abilities/users_spec.rb;
+And its associated test spec/abilities/users_spec.rb will look something like this:
 
     require_relative '../spec_helper'
     require "cancan/matchers"
@@ -89,7 +88,7 @@ And it's associated test spec/abilities/users_spec.rb;
 
     end
 
-You can also re-use abilities defined for one role in another. This allows you to 'inherit' abilities without having to assign all of the roles to the user. To do this, pass a list of role names to the includes_abilities_of method
+You can also re-use abilities defined for one role in another. This allows you to 'inherit' abilities without having to assign all of the roles to the user. To do this, pass a list of role names to the includes_abilities_of method:
 
     Canard::Abilities.for(:writer) do
 
@@ -112,48 +111,48 @@ You can also re-use abilities defined for one role in another. This allows you t
 
     end
 
-A user assigned the :admin role will have all of the abilities of the :writer and :reviewer, along with their own abilities without having to have those individual roles assigned to them.
+A user assigned the :admin role will have all of the abilities of the :writer and :reviewer, along with their own abilities, without having to have those individual roles assigned to them.
 
-Now lets generate some abilities for the manager and admin.
+Now let's generate some abilities for the manager and admin:
 
     $ rails g canard:ability admin can:manage:[account,statement]
     $ rails g canard:ability manager can:edit:statement
 
-Gives us two new sets of abilities in the abilities folder. Canard will apply these abilities by first
-loading the ability for the User model and then apply the abilities for each role the current user has.
+This generates two new sets of abilities in the abilities folder. Canard will apply these abilities by first
+loading the ability for the User model and then applying the abilities for each of the current user's roles.
 
 
-If there is no user (i.e. logged out) Canard creates a guest and looks for a guest ability to apply so:
+If there is no user (i.e. logged out), Canard creates a guest and looks for a guest ability to apply:
 
     $ rails g canard:ability guest can:create:user
 
-Would generate an ability for a not logged in user to signup.
+This would generate a signup ability for a user who was not logged in.
 
-Obviously the generators are just a starting point and should  be used only to get you going. I strongly
-suggest that every new model you create you add to the abilities as the specs are easy to write and CanCan
+Obviously the generators are just a starting point and should be used only to get you going. I strongly
+suggest that you add each new model to the abilities because the specs are easy to write and CanCan
 definitions are very clear and simple.
 
 Scopes
 ======
-The :acts_as_user method with automatically define some named scopes for each role. For the example User model
-above it will define the following scopes;
+The :acts_as_user method will automatically define some named scopes for each role. For the User model
+above it will define the following scopes:
 
-User.admins::       return all the users with the admin role
-User.non_admins::   return all the users without the admin role
-User.managers::     return all the users with the manager role
-User.non_managers:: return all the users without the manager role
+`User.admins::`       return all the users with the admin role   
+`User.non_admins::`   return all the users without the admin role   
+`User.managers::`     return all the users with the manager role   
+`User.non_managers::` return all the users without the manager role   
 
-In addition to the role specific scopes it also adds some general scopes;
+In addition to the role specific scopes it also adds some general scopes:
 
-User.with_any_role(roles)::   return all the users with any of the specified roles
-User.with_all_roles(roles)::  return only the users with all the specified roles
+`User.with_any_role(roles)::`   return all the users with any of the specified roles   
+`User.with_all_roles(roles)::`  return only the users with all the specified roles   
 
 Installation
 ============
 
 Rails 3.x, 4.x & 5.x
 --------------------
-Add the canard gem to your Gemfile. In Gemfile:
+Add the canard gem to your Gemfile:
 
     gem "canard"
 
@@ -167,20 +166,20 @@ That's it!
 Rails 2.x
 ---------
 
-Sorry you are out of luck with Rails 2.x Canard has only been written and tested with Rails 3 and above.
+Sorry, you are out of luck. Canard has only been written and tested with Rails 3 and above.
 
-Supported ORM's
+Supported ORMs
 ---------------
 
 Canard is ORM agnostic. ActiveRecord and Mongoid (thanks David Butler) adapters are currently implemented.
-New adapters can easily be added, but you'd need to check CanCan can also support your adapter.
+New adapters can easily be added, but you'd need to check to see if CanCan can also support your adapter.
 
 Further reading
 ---------------
 
-Canard stands on the sholders of Ryan Bates' CanCan and Martin Rehfeld's RoleModel. You can read more
+Canard stands on the shoulders of Ryan Bates' CanCan and Martin Rehfeld's RoleModel. You can read more
 about defining abilities on the CanCan wiki (https://github.com/ryanb/cancan/wiki). Canard implements
-the Ability class for you so you don't need the boilerplate code from Ryan's example;
+the Ability class for you so you don't need the boilerplate code from Ryan's example:
 
     class Ability
       include CanCan::Ability
@@ -195,13 +194,13 @@ the Ability class for you so you don't need the boilerplate code from Ryan's exa
       end
     end
 
-The Canard equivalent for non admins would be;
+The Canard equivalent for non-admins would be:
 
     Canard::Abilities.for(:user) do
       can :read, :all
     end
 
-And for Admins;
+And for admins:
 
     Canard::Abilities.for(:admin) do
       can :manage, :all
@@ -217,8 +216,8 @@ Note on Patches/Pull Request
 * Fork the project.
 * Make your feature addition or bug fix.
 * Add tests for it (when I have some). This is important so I don't break it in a future version unintentionally.
-* Commit, do not mess with rakefile, version, or history. (if you want to have your own version, that is fine but
-  bump version in a commit by itself I can ignore it when I pull)
+* Commit. Do not mess with rakefile, version, or history. (If you want to have your own version, that is fine but
+  bump version in a commit by itself so I can ignore it when I pull.)
 * Send me a pull request.  Bonus points for topic branches.
 
 Contributors

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-= Canard
-== Overview
+Canard
+======
+[![Build Status](https://travis-ci.org/james2m/canard.svg?branch=master)](https://travis-ci.org/james2m/canard)
+
 Canard brings CanCan and RoleModel together to make role based authorization in Rails easy. Your ability
 definitions gain their own folder and a little structure. The easiest way to get started is with the
 Canard generator. Canard progressively enhances the abilities of the model by applying role abilities on
 top of the models base abilities.
-
 A User model with :admin and :manager roles would be defined:
 
     class User < ActiveRecord::Base
@@ -22,7 +23,8 @@ First it will look for a users abilities, then it will look for the roles in the
 
 Therefore each the later abilities only need to build on their predecessors.
 
-== Usage
+Usage
+=====
 To generate some abilities for the User.
 
     $ rails g canard:ability user can:[read,create]:[account,statement] cannot:destroy:account
@@ -131,8 +133,8 @@ Obviously the generators are just a starting point and should  be used only to g
 suggest that every new model you create you add to the abilities as the specs are easy to write and CanCan
 definitions are very clear and simple.
 
-== Scopes
-
+Scopes
+======
 The :acts_as_user method with automatically define some named scopes for each role. For the example User model
 above it will define the following scopes;
 
@@ -146,10 +148,11 @@ In addition to the role specific scopes it also adds some general scopes;
 User.with_any_role(roles)::   return all the users with any of the specified roles
 User.with_all_roles(roles)::  return only the users with all the specified roles
 
-== Installation
+Installation
+============
 
-=== Rails 3.x, 4.x & 5.x
-
+Rails 3.x, 4.x & 5.x
+--------------------
 Add the canard gem to your Gemfile. In Gemfile:
 
     gem "canard"
@@ -161,16 +164,19 @@ Add the `roles_mask` field to your user table:
 
 That's it!
 
-=== Rails 2.x
+Rails 2.x
+---------
 
 Sorry you are out of luck with Rails 2.x Canard has only been written and tested with Rails 3 and above.
 
-== Supported ORM's
+Supported ORM's
+---------------
 
 Canard is ORM agnostic. ActiveRecord and Mongoid (thanks David Butler) adapters are currently implemented.
 New adapters can easily be added, but you'd need to check CanCan can also support your adapter.
 
-== Further reading
+Further reading
+---------------
 
 Canard stands on the sholders of Ryan Bates' CanCan and Martin Rehfeld's RoleModel. You can read more
 about defining abilities on the CanCan wiki (https://github.com/ryanb/cancan/wiki). Canard implements
@@ -205,7 +211,8 @@ Under the covers Canard uses RoleModel (https://github.com/martinrehfeld/role_mo
 is based on Ryan Bates' suggested approach to role based authorization which is documented in the CanCan
 wiki (https://github.com/ryanb/cancan/wiki/role-based-authorization).
 
-== Note on Patches/Pull Request
+Note on Patches/Pull Request
+----------------------------
 
 * Fork the project.
 * Make your feature addition or bug fix.
@@ -214,21 +221,33 @@ wiki (https://github.com/ryanb/cancan/wiki/role-based-authorization).
   bump version in a commit by itself I can ignore it when I pull)
 * Send me a pull request.  Bonus points for topic branches.
 
-== Contributors
+Contributors
+------------
 
     git log | grep Author | sort | uniq
 
-* James McCarthy
-* Joey Geiger
-* Morton Jonuschat
+* Alessandro Dal Grande
 * David Butler
+* Dmitriy Molodtsov
+* Dmytro Salko
+* James McCarthy
+* Jesse McGinnis
+* Joey Geiger
+* Jon Kinney
+* Justin Buchanan
+* Morton Jonuschat
+* Piotr Kuczynski
+* Thomas Hoen
+* Travis Berry
 
 If you feel like contributing there is a TODO list in the root with a few ideas and opportunities!
 
-== Credits
+Credits
+-------
 
 Thanks to Ryan Bates for creating the awesome CanCan (http://wiki.github.com/ryanb/cancan)
 and Martin Rehfeld for implementing Role Based Authorization in the form of RoleModel (http://github.com/martinrehfeld/role_model).
 
-== Copyright
-Copyright (c) 2011 James McCarthy, released under the MIT license
+Copyright
+---------
+Copyright (c) 2011-2017 James McCarthy, released under the MIT license

--- a/README.rdoc
+++ b/README.rdoc
@@ -148,7 +148,7 @@ User.with_all_roles(roles)::  return only the users with all the specified roles
 
 == Installation
 
-=== Rails 3.x & 4.x
+=== Rails 3.x, 4.x & 5.x
 
 Add the canard gem to your Gemfile. In Gemfile:
 
@@ -163,8 +163,7 @@ That's it!
 
 === Rails 2.x
 
-Sorry you are out of luck with Rails 2.x Canard has only been written and tested with Rails 3.x. I'll be happy
-to accept pull requests for tested Rails 2.x updates if anybody is game.
+Sorry you are out of luck with Rails 2.x Canard has only been written and tested with Rails 3 and above.
 
 == Supported ORM's
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -9,7 +9,7 @@ A User model with :admin and :manager roles would be defined:
 
     class User < ActiveRecord::Base
 
-      acts_as_user :roles =>  :manager, :admin
+      acts_as_user :roles => [ :manager, :admin ]
 
     end
 

--- a/TODO
+++ b/TODO
@@ -8,3 +8,4 @@
 * Make the Ability user referece configureable in Ability.
 * Add DataMapper support.
 * Detect and use FactoryGirl syntax in generated spec.
+* Stop extending ActiveRecord, use composition instead.

--- a/canard.gemspec
+++ b/canard.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'mongoid', '~> 3.0'
 
   s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
-  s.add_runtime_dependency 'cancancan', '~> 1'
+  s.add_runtime_dependency 'cancancan', '>= 1'
   s.add_runtime_dependency 'role_model', '~> 0'
 end

--- a/canard.gemspec
+++ b/canard.gemspec
@@ -9,8 +9,8 @@ Gem::Specification.new do |s|
   s.authors     = ["James McCarthy"]
   s.email       = ["james2mccarthy@gmail.com"]
   s.homepage    = "https://github.com/james2m/canard"
-  s.summary     = %q{Adds role based authorisation to Rails by combining RoleModel and CanCan.}
-  s.description = %q{Wraps CanCan and RoleModel up to make role based authorisation really easy in Rails 3.x.}
+  s.summary     = %q{Adds role based authorisation to Rails by combining RoleModel and CanCanCan.}
+  s.description = %q{Wraps CanCanCan and RoleModel up to make role based authorisation really easy in Rails 4+.}
 
   s.rubyforge_project = "canard"
 
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency "mongoid", "~> 3.0"
   end
 
-  s.requirements << 'cancan for Rails3 and earlier or the Rails4 compatible cancancan fork.'
+  s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
   s.add_runtime_dependency "cancancan"
   s.add_runtime_dependency "role_model"
 end

--- a/canard.gemspec
+++ b/canard.gemspec
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
 $:.push File.expand_path("../lib", __FILE__)
-require "canard/version"
+require 'canard/version'
 
 Gem::Specification.new do |s|
-  s.name        = "canard"
+  s.name        = 'canard'
   s.version     = Canard::VERSION
   s.date        = `git log -1 --format="%cd" --date=short lib/canard/version.rb`
-  s.authors     = ["James McCarthy"]
-  s.email       = ["james2mccarthy@gmail.com"]
-  s.homepage    = "https://github.com/james2m/canard"
+  s.authors     = ['James McCarthy']
+  s.email       = ['james2mccarthy@gmail.com']
+  s.homepage    = 'https://github.com/james2m/canard'
   s.summary     = %q{Adds role based authorisation to Rails by combining RoleModel and CanCanCan.}
   s.description = %q{Wraps CanCanCan and RoleModel up to make role based authorisation really easy in Rails 4+.}
 
@@ -17,18 +17,13 @@ Gem::Specification.new do |s|
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+  s.require_paths = ['lib']
 
-  s.add_development_dependency "minitest", "~> 2"
-  s.add_development_dependency "rails", "~> 3.2.3"
-
-  if RUBY_VERSION < '1.9'
-    s.add_development_dependency "mongoid", "~> 2.0"
-  else
-    s.add_development_dependency "mongoid", "~> 3.0"
-  end
+  s.add_development_dependency 'minitest', '~> 2'
+  s.add_development_dependency 'rails', '~> 3.2.3', '>= 3.2.3'
+  s.add_development_dependency 'mongoid', '~> 3.0'
 
   s.requirements << "cancan's community supported Rails4+ compatible cancancan fork."
-  s.add_runtime_dependency "cancancan"
-  s.add_runtime_dependency "role_model"
+  s.add_runtime_dependency 'cancancan', '~> 1'
+  s.add_runtime_dependency 'role_model', '~> 0'
 end

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -5,7 +5,7 @@ module Canard
       private
 
       def add_role_scopes(*args)
-        options = args.extract_options!        
+        options = args.extract_options!
         # TODO change to check has_roles_attribute?
         if active_record_table?
           valid_roles.each do |role|
@@ -37,9 +37,8 @@ module Canard
       end
 
       def define_scopes_for_role(role, prefix=nil)
-        prefix = prefix ? "#{prefix}_" : ''
-        include_scope   = "#{prefix}#{role.to_s.pluralize}"
-        exclude_scope   = "non_#{include_scope}"
+        include_scope = [prefix, String(role).pluralize].compact.join('_')
+        exclude_scope = "non_#{include_scope}"
 
         define_scope_method(include_scope) do
           where("#{role_mask_column} & :role_mask > 0", { :role_mask => mask_for(role) })

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -13,15 +13,15 @@ module Canard
           end
 
           # TODO change hard coded :role_mask to roles_attribute_name
-          define_scope_method(:with_any_role) do |*roles|
+          define_singleton_method(:with_any_role) do |*roles|
             where("#{role_mask_column} & :role_mask > 0", { :role_mask => mask_for(*roles) })
           end
 
-          define_scope_method(:with_all_roles) do |*roles|
+          define_singleton_method(:with_all_roles) do |*roles|
             where("#{role_mask_column} & :role_mask = :role_mask", { :role_mask => mask_for(*roles) })
           end
 
-          define_scope_method(:with_only_roles) do |*roles|
+          define_singleton_method(:with_only_roles) do |*roles|
             where("#{role_mask_column} = :role_mask", { :role_mask => mask_for(*roles) })
           end
         end
@@ -40,25 +40,18 @@ module Canard
         include_scope = [prefix, String(role).pluralize].compact.join('_')
         exclude_scope = "non_#{include_scope}"
 
-        define_scope_method(include_scope) do
+        define_singleton_method(include_scope) do
           where("#{role_mask_column} & :role_mask > 0", { :role_mask => mask_for(role) })
         end
 
-        define_scope_method(exclude_scope) do
+        define_singleton_method(exclude_scope) do
           where("#{role_mask_column} & :role_mask = 0 or #{role_mask_column} is null", { :role_mask => mask_for(role) })
-        end
-      end
-
-      def define_scope_method(method, &block)
-        (class << self; self end).class_eval do
-          define_method(method, block)
         end
       end
 
       def role_mask_column
         "#{quoted_table_name}.#{connection.quote_column_name roles_attribute_name}"
       end
-
     end
   end
 end

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -37,7 +37,7 @@ module Canard
       end
 
       def define_scopes_for_role(role, prefix=nil)
-        prefix = prefix? "#{prefix}_" : ''
+        prefix = prefix ? "#{prefix}_" : ''
         include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -38,7 +38,7 @@ module Canard
 
       def define_scopes_for_role(role, prefix=nil)
         prefix = prefix ? "#{prefix}_" : ''
-        include_scope   = "#{prefix}role.to_s.pluralize"
+        include_scope   = "#{prefix}#{role.to_s.pluralize}"
         exclude_scope   = "non_#{include_scope}"
 
         define_scope_method(include_scope) do

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -5,12 +5,11 @@ module Canard
       private
 
       def add_role_scopes(*args)
-        options = args.extract_options!
-        prefix = "#{options[:prefix]}_" || ''
+        options = args.extract_options!        
         # TODO change to check has_roles_attribute?
         if active_record_table?
           valid_roles.each do |role|
-            define_scopes_for_role role, prefix
+            define_scopes_for_role role, options[:prefix]
           end
 
           # TODO change hard coded :role_mask to roles_attribute_name
@@ -37,7 +36,8 @@ module Canard
         active_record_table? && column_names.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role, prefix)
+      def define_scopes_for_role(role, prefix=nil)
+        prefix = prefix? "#{prefix}_" : ''
         include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 

--- a/lib/canard/adapters/active_record.rb
+++ b/lib/canard/adapters/active_record.rb
@@ -4,11 +4,13 @@ module Canard
 
       private
 
-      def add_role_scopes
+      def add_role_scopes(*args)
+        options = args.extract_options!
+        prefix = "#{options[:prefix]}_" || ''
         # TODO change to check has_roles_attribute?
         if active_record_table?
           valid_roles.each do |role|
-            define_scopes_for_role role
+            define_scopes_for_role role, prefix
           end
 
           # TODO change hard coded :role_mask to roles_attribute_name
@@ -35,8 +37,8 @@ module Canard
         active_record_table? && column_names.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role)
-        include_scope   = role.to_s.pluralize
+      def define_scopes_for_role(role, prefix)
+        include_scope   = "#{prefix}role.to_s.pluralize"
         exclude_scope   = "non_#{include_scope}"
 
         define_scope_method(include_scope) do

--- a/lib/canard/adapters/mongoid.rb
+++ b/lib/canard/adapters/mongoid.rb
@@ -5,7 +5,7 @@ module Canard
       private
 
       def add_role_scopes(*args)
-        options = args.extract_options!   
+        options = args.extract_options!
         valid_roles.each do |role|
           define_scopes_for_role role, options[:prefix]
         end
@@ -28,10 +28,9 @@ module Canard
       end
 
       def define_scopes_for_role(role, prefix=nil)
-        prefix = prefix ? "#{prefix}_" : ''
-        include_scope   = "#{prefix}#{role.to_s.pluralize}"
-        exclude_scope   = "non_#{include_scope}"
-        
+        include_scope = [prefix, String(role).pluralize].compact.join('_')
+        exclude_scope = "non_#{include_scope}"
+
         scope include_scope, lambda { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }
         scope exclude_scope, lambda { any_of({roles_attribute_name  => { "$exists" => false }}, {roles_attribute_name => nil}, {"$where" => "(this.#{roles_attribute_name} & #{mask_for(role)}) === 0"}) }
       end

--- a/lib/canard/adapters/mongoid.rb
+++ b/lib/canard/adapters/mongoid.rb
@@ -4,9 +4,10 @@ module Canard
 
       private
 
-      def add_role_scopes
+      def add_role_scopes(*args)
+        options = args.extract_options!   
         valid_roles.each do |role|
-          define_scopes_for_role role
+          define_scopes_for_role role, options[:prefix]
         end
 
         def with_any_role(*roles)
@@ -26,8 +27,9 @@ module Canard
        fields.include?(roles_attribute_name.to_s) || super
       end
 
-      def define_scopes_for_role(role)
-        include_scope   = role.to_s.pluralize
+      def define_scopes_for_role(role, prefix=nil)
+        prefix = prefix ? "#{prefix}_" : ''
+        include_scope   = "#{prefix}#{role.to_s.pluralize}"
         exclude_scope   = "non_#{include_scope}"
         
         scope include_scope, lambda { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }

--- a/lib/canard/adapters/mongoid.rb
+++ b/lib/canard/adapters/mongoid.rb
@@ -31,10 +31,9 @@ module Canard
         include_scope = [prefix, String(role).pluralize].compact.join('_')
         exclude_scope = "non_#{include_scope}"
 
-        scope include_scope, lambda { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }
-        scope exclude_scope, lambda { any_of({roles_attribute_name  => { "$exists" => false }}, {roles_attribute_name => nil}, {"$where" => "(this.#{roles_attribute_name} & #{mask_for(role)}) === 0"}) }
+        scope include_scope, -> { where("(this.#{roles_attribute_name} & #{mask_for(role)}) > 0") }
+        scope exclude_scope, -> { any_of({roles_attribute_name  => { "$exists" => false }}, {roles_attribute_name => nil}, {"$where" => "(this.#{roles_attribute_name} & #{mask_for(role)}) === 0"}) }
       end
-
     end
   end
 end

--- a/lib/canard/railtie.rb
+++ b/lib/canard/railtie.rb
@@ -31,15 +31,20 @@ module Canard
     end
 
     initializer "canard.abilities_reloading", :after => "action_dispatch.configure" do |app|
-      if ActionDispatch::Reloader.respond_to?(:to_prepare)
-        ActionDispatch::Reloader.to_prepare { Canard.find_abilities }
+      reloader = rails5? ? ActiveSupport::Reloader : ActionDispatch::Reloader
+      if reloader.respond_to?(:to_prepare)
+        reloader.to_prepare { Canard.find_abilities }
       else
-        ActionDispatch::Reloader.before { Canard.find_abilities }
+        reloader.before { Canard.find_abilities }
       end
     end
 
     rake_tasks do
       load File.expand_path('../../tasks/canard.rake', __FILE__)
+    end
+
+    def rails5?
+      Gem.loaded_specs['activesupport'].version >= Gem::Version.new('5.0.0.beta')
     end
   end
 end

--- a/lib/canard/railtie.rb
+++ b/lib/canard/railtie.rb
@@ -25,17 +25,13 @@ module Canard
     end
 
     initializer "canard.mongoid" do |app|
-      if defined?(Mongoid)
-        require 'canard/adapters/mongoid'
-      end
+      require 'canard/adapters/mongoid' if defined?(Mongoid)
     end
 
     initializer "canard.abilities_reloading", :after => "action_dispatch.configure" do |app|
       reloader = rails5? ? ActiveSupport::Reloader : ActionDispatch::Reloader
       if reloader.respond_to?(:to_prepare)
         reloader.to_prepare { Canard.find_abilities }
-      else
-        reloader.before { Canard.find_abilities }
       end
     end
 
@@ -43,8 +39,10 @@ module Canard
       load File.expand_path('../../tasks/canard.rake', __FILE__)
     end
 
+    private
+
     def rails5?
-      Gem.loaded_specs['activesupport'].version >= Gem::Version.new('5.0.0.beta')
+      ActionPack::VERSION::MAJOR == 5
     end
   end
 end

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      # add_role_scopes if respond_to?(:add_role_scopes, true)
+      add_role_scopes(options[:prefix]) if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      add_role_scopes if respond_to?(:add_role_scopes, true)
+      # add_role_scopes if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/user_model.rb
+++ b/lib/canard/user_model.rb
@@ -73,7 +73,7 @@ module Canard
 
       roles options[:roles] if options.has_key?(:roles) && has_roles_mask_accessors?
 
-      add_role_scopes(options[:prefix]) if respond_to?(:add_role_scopes, true)
+      add_role_scopes(prefix: options[:prefix]) if respond_to?(:add_role_scopes, true)
     end
 
     private

--- a/lib/canard/version.rb
+++ b/lib/canard/version.rb
@@ -1,3 +1,3 @@
 module Canard
-  VERSION = "0.4.4"
+  VERSION = "0.5.0.pre"
 end

--- a/lib/canard/version.rb
+++ b/lib/canard/version.rb
@@ -1,3 +1,3 @@
 module Canard
-  VERSION = "0.4.3"
+  VERSION = "0.4.4"
 end

--- a/lib/generators/canard/ability/templates/abilities.rb.erb
+++ b/lib/generators/canard/ability/templates/abilities.rb.erb
@@ -1,5 +1,4 @@
 Canard::Abilities.for(<%= ":#{name}" -%>) do
-
 <% if ability_definitions.empty? -%>
   # Define abilities for the user role here. For example:
   #
@@ -19,14 +18,13 @@ Canard::Abilities.for(<%= ":#{name}" -%>) do
   # The third argument is an optional hash of conditions to further filter the objects.
   # For example, here the user can only update published articles.
   #
-  #   can :update, Article, :published => true
+  #   can :update, Article, published: true
   #
-  # See the wiki for details: https://github.com/ryanb/cancan/wiki/Defining-Abilities
+  # See the wiki for details: https://github.com/CanCanCommunity/cancancan/wiki/Defining-Abilities
 <% else -%>
 <% definitions do |model, definition| -%>
-  <%= "can".ljust(8, ' ') + "#{definition.cans.map(&:to_sym)}, #{model.classify}" unless definition.cans.empty? %>
-  <%= "cannot".ljust(8, ' ') + "#{definition.cannots.map(&:to_sym)}, #{model.classify}" unless definition.cannots.empty? %>
+  <%= "can #{definition.cans.map(&:to_sym)}, #{model.classify}" unless definition.cans.empty? %>
+  <%= "cannot #{definition.cannots.map(&:to_sym)}, #{model.classify}" unless definition.cannots.empty? %>
 <% end -%>
 <% end -%>
-
 end

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -1,68 +1,42 @@
-require_relative '../spec_helper'
+require 'rails_helper'
+require 'cancan/matchers'
 
-require "cancan/matchers"
-
-describe Canard::Abilities, "for <%= plural_name %>" do
-
-  before do
+describe Canard::Abilities, 'for <%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-    @user = Factory.create(:<%= name %>_user)
+  let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-    @user = User.make!(:<%= name %>)
+  let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
-  @user = User.create(:roles => %w(<%= name -%>))
+  let(:<%= name %>) { User.create(roles: %w(<%= name -%>)) }
 <% end -%>
-  end
-  
-  subject { Ability.new(@user) }
-  
+
+  subject(:<%= name %>_ability) { Ability.new(<%= name %>) }
+
 <% if ability_definitions.empty? -%>
-# Define your ability tests thus;
-#
-#  describe 'on Activity' do
-#
-#    before do
-#      @activity = Factory.create(:activity)
-#    end
-#
-#    it { should be_able_to( :index,    Activity  ) }
-#    it { should be_able_to( :show,     @activity ) }
-#    it { should be_able_to( :read,     @activity ) }
-#    it { should be_able_to( :new,      @activity ) }
-#    it { should be_able_to( :create,   @activity ) }
-#    it { should be_able_to( :edit,     @activity ) }
-#    it { should be_able_to( :update,   @activity ) }
-#    it { should be_able_to( :destroy,  @activity ) }
-#
-#  end
-#  # on Activity
+#   # Define your ability tests thus;
+#   describe 'on <%= name.camelize %>' do
+#     it { is_expected.to be_able_to(:index,   <%= name.camelize %>) }
+#     it { is_expected.to be_able_to(:show,    <%= name %>) }
+#     it { is_expected.to be_able_to(:read,    <%= name %>) }
+#     it { is_expected.to be_able_to(:new,     <%= name %>) }
+#     it { is_expected.to be_able_to(:create,  <%= name %>) }
+#     it { is_expected.to be_able_to(:edit,    <%= name %>) }
+#     it { is_expected.to be_able_to(:update,  <%= name %>) }
+#     it { is_expected.to be_able_to(:destroy, <%= name %>) }
+#   end
+#   # on <%= name.camelize %>
 <% else -%>
 <% definitions do |model, definition| -%>
   <% model_name = model.camelize -%>
-  
-  describe 'on <%= model_name -%>' do
-
-    before do
-<% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-      @<%= model -%> = Factory.create(:<%= model -%>)
-<% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-      @<%= model -%> = <%= model_name -%>.make!
-<% else -%>
-      @<%= model -%> = <%= model_name -%>.create
-<% end -%>
-    end
-    
+describe 'on <%= model_name -%>' do
 <% definition.cans.each do |can| -%>
-    it { should be_able_to( <%= ":#{can},".ljust(12, ' ') + "@#{model}" -%> ) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { should_not be_able_to( <%= ":#{cannot},".ljust(12, ' ') + "@#{model}" -%> ) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
 <% end -%>
-
   end
   # on <%= model_name %>
-  <% end -%>
-  
-<% end -%>  
+<% end -%>
+<% end -%>
 end
-  

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -29,11 +29,19 @@ describe Canard::Abilities, '#<%= plural_name %>' do
 <% definitions do |model, definition| -%>
   <% model_name = model.camelize -%>
 describe 'on <%= model_name -%>' do
+<% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
+    let(:<%= model -%>) { FactoryGirl.create(:<%= model -%>) }
+<% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
+    let(:<%= model -%>) { <%= model_name -%>.make! }
+<% else -%>
+    let(:<%= model -%>) { <%= model_name -%>.create }
+<% end -%>
+
 <% definition.cans.each do |can| -%>
-    it { is_expected.to be_able_to(<%= ":#{can}, #{name}" -%>) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{name}" -%>) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
 <% end -%>
   end
   # on <%= model_name %>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:user, :<%= name %>) }
+  let(:<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
   let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,7 +3,7 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
+  let(:<%= name %>) { FactoryGirl.create(:user, :<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
   let(:<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
@@ -30,10 +30,10 @@ describe Canard::Abilities, '#<%= plural_name %>' do
   <% model_name = model.camelize -%>
 describe 'on <%= model_name -%>' do
 <% definition.cans.each do |can| -%>
-    it { is_expected.to be_able_to(<%= ":#{can}, #{model}" -%>) }
+    it { is_expected.to be_able_to(<%= ":#{can}, #{name}" -%>) }
 <% end -%>
 <%- definition.cannots.each do |cannot| -%>
-    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{model}" -%>) }
+    it { is_expected.to_not be_able_to(<%= ":#{cannot}, #{name}" -%>) }
 <% end -%>
   end
   # on <%= model_name %>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'cancan/matchers'
 
-describe Canard::Abilities, 'for <%= plural_name %>' do
+describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
   let(:<%= name %>) { FactoryGirl.create(:<%= name %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>

--- a/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
+++ b/lib/generators/rspec/ability/templates/abilities_spec.rb.erb
@@ -3,18 +3,19 @@ require 'cancan/matchers'
 
 describe Canard::Abilities, '#<%= plural_name %>' do
 <% if Rails.configuration.generators.options[:rails][:fixture_replacement] == :factory_girl -%>
-  let(:<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
+  let(:acting_<%= name %>) { FactoryGirl.create(:user<%= name == 'user' ? '' : ", :#{name}" %>) }
 <% elsif Rails.configuration.generators.options[:rails][:fixture_replacement] == :machinist -%>
-  let(:<%= name %>) { User.make!(:<%= name %>) }
+  let(:acting_<%= name %>) { User.make!(:<%= name %>) }
 <% else -%>
-  let(:<%= name %>) { User.create(roles: %w(<%= name -%>)) }
+  let(:acting_<%= name %>) { User.create(roles: %w(<%= name -%>)) }
 <% end -%>
-
-  subject(:<%= name %>_ability) { Ability.new(<%= name %>) }
+  subject(:<%= name %>_ability) { Ability.new(acting_<%= name %>) }
 
 <% if ability_definitions.empty? -%>
 #   # Define your ability tests thus;
 #   describe 'on <%= name.camelize %>' do
+#     let(:<%= name %>) { FactoryGirl.create(<%= name %>) }
+#
 #     it { is_expected.to be_able_to(:index,   <%= name.camelize %>) }
 #     it { is_expected.to be_able_to(:show,    <%= name %>) }
 #     it { is_expected.to be_able_to(:read,    <%= name %>) }


### PR DESCRIPTION
This brings the gem up to date with the main Canard repo, and then updates its `gemspec` file to allow CanCanCan versions > 1.x, since in CanCanCan v2.3.0 the deprecation warnings for Rails 6 have been fixed.